### PR TITLE
Fixed build error when boost v1.66 over was used.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -12,6 +12,9 @@
 #include "db.h"
 
 #undef printf
+#if BOOST_VERSION >= 106600
+#define BOOST_ASIO_ENABLE_OLD_SERVICES
+#endif
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
 #include <boost/bind.hpp>
@@ -800,7 +803,11 @@ void ThreadRPCServer2(void* parg)
 
     asio::io_service io_service;
 
+#if BOOST_VERSION >= 106600
+    ssl::context context(ssl::context::sslv23);
+#else
     ssl::context context(io_service, ssl::context::sslv23);
+#endif
     if (fUseSSL)
     {
         context.set_options(ssl::context::no_sslv2);
@@ -816,7 +823,11 @@ void ThreadRPCServer2(void* parg)
         else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
 
         string strCiphers = GetArg("-rpcsslciphers", "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");
+#if BOOST_VERSION >= 106600
+        SSL_CTX_set_cipher_list(context.native_handle(), strCiphers.c_str());
+#else
         SSL_CTX_set_cipher_list(context.impl(), strCiphers.c_str());
+#endif
     }
 
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
@@ -1111,7 +1122,11 @@ Object CallRPC(const string& strMethod, const Array& params)
     // Connect to localhost
     bool fUseSSL = GetBoolArg("-rpcssl");
     asio::io_service io_service;
+#if BOOST_VERSION >= 106600
+    ssl::context context(ssl::context::sslv23);
+#else
     ssl::context context(io_service, ssl::context::sslv23);
+#endif
     context.set_options(ssl::context::no_sslv2);
     asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_service, context);
     SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);


### PR DESCRIPTION
# Background
boost v1.66 changes some APIs of boost.Asio, It affects XPCoin build error.

http://www.boost.org/users/history/version_1_66_0.html

# Changes
- added  `BOOST_ASIO_ENABLE_OLD_SERVICES` macros when boost v1.66 over was used. this macros allows to use `basic_socket<Protocol, SocketService>`.
- used recommended APIs because boost v1.66 deleted deprecated functions.