### PR TITLE
add counting message of loading block index

### DIFF
--- a/src/txdb-bdb.cpp
+++ b/src/txdb-bdb.cpp
@@ -9,6 +9,7 @@
 #include "txdb-bdb.h"
 #include "util.h"
 #include "main.h"
+#include "ui_interface.h"
 #include <boost/version.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -362,6 +363,9 @@ bool CTxDB::LoadBlockIndexGuts()
 
     // Load mapBlockIndex
     unsigned int fFlags = DB_SET_RANGE;
+
+    uint32_t count = 0;
+    std::string msg;
     while (true)
     {
         // Read next record
@@ -407,6 +411,13 @@ bool CTxDB::LoadBlockIndexGuts()
             pindexNew->nTime          = diskindex.nTime;
             pindexNew->nBits          = diskindex.nBits;
             pindexNew->nNonce         = diskindex.nNonce;
+
+            count++;
+            if (count % 10000 == 0){
+                msg = _("Loading block index...");
+                printf("%s %" PRIu32 "\n", msg.c_str(), count);
+                uiInterface.InitMessage(strprintf("%s\n%" PRIu32, msg.c_str(), count));
+            }
 
             // Watch for genesis block
             if (pindexGenesisBlock == NULL && blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -19,6 +19,7 @@
 #include "txdb.h"
 #include "util.h"
 #include "main.h"
+#include "ui_interface.h"
 
 using namespace std;
 using namespace boost;
@@ -349,6 +350,9 @@ bool CTxDB::LoadBlockIndex()
     CDataStream ssStartKey(SER_DISK, CLIENT_VERSION);
     ssStartKey << make_pair(string("blockindex"), uint256(0));
     iterator->Seek(ssStartKey.str());
+
+    uint32_t count = 0;
+    std::string msg;
     // Now read each entry.
     while (iterator->Valid())
     {
@@ -386,6 +390,13 @@ bool CTxDB::LoadBlockIndex()
         pindexNew->nTime          = diskindex.nTime;
         pindexNew->nBits          = diskindex.nBits;
         pindexNew->nNonce         = diskindex.nNonce;
+
+        count++;
+        if (count % 10000 == 0){
+            msg = _("Loading block index...");
+            printf("%s %" PRIu32 "\n", msg.c_str(), count);
+            uiInterface.InitMessage(strprintf("%s\n%" PRIu32, msg.c_str(), count));
+        }
 
         // Watch for genesis block
         if (pindexGenesisBlock == NULL && blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))


### PR DESCRIPTION
While block index is loading when start up, it looks like to be doing nothing.
For a simple solution, added counter message.
![xp-loading](https://user-images.githubusercontent.com/146196/34382092-eea9c5f0-eb4f-11e7-970b-d64dd3ca4a1f.png)

