### PR TITLE
fix problem with connection to 1.1.0 from 1.1.0.1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3099,10 +3099,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CAddress addrFrom;
         uint64_t nNonce = 1;
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
-        if (pfrom->nVersion < MIN_PROTO_VERSION)
+        if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
-            // Since February 20, 2012, the protocol is initiated at version 209,
-            // and earlier versions are no longer supported
+            // disconnect from peers older than this proto version
             printf("partner %s using obsolete version %i; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;

--- a/src/net.h
+++ b/src/net.h
@@ -223,7 +223,7 @@ public:
     CCriticalSection cs_inventory;
     std::multimap<int64_t, CInv> mapAskFor;
 
-    CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false) : vSend(SER_NETWORK, MIN_PROTO_VERSION), vRecv(SER_NETWORK, MIN_PROTO_VERSION)
+    CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false) : vSend(SER_NETWORK, INIT_PROTO_VERSION), vRecv(SER_NETWORK, INIT_PROTO_VERSION)
     {
         nServices = 0;
         hSocket = hSocketIn;

--- a/src/version.h
+++ b/src/version.h
@@ -32,8 +32,11 @@ static const int DATABASE_VERSION = 70507;
 
 static const int PROTOCOL_VERSION = 91000;
 
-// earlier versions not supported as of Feb 2012, and are disconnected
-static const int MIN_PROTO_VERSION = 91000;
+// intial proto version, to be increased after version/verack negotiation
+static const int INIT_PROTO_VERSION = 209;
+
+// disconnect from peers older than this proto version
+static const int MIN_PEER_PROTO_VERSION = 91000;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
`MIN_PROTO_VERSION` is must less than `CADDR_TIME_VERSION`.
There is a problem with deserializing with `CAddress`, and it will be impossible to connect with the 1.1.0 clients.
I modified it based on bitcoin/bitcoin#3155.
